### PR TITLE
Adds why3:alt-ergo as a prover and a Cocci file for memb_init

### DIFF
--- a/verif/contiki_extricate.conf
+++ b/verif/contiki_extricate.conf
@@ -8,6 +8,7 @@ plugin-spatch=set_iv^verif/patches/set_iv.cocci
 plugin-spatch=mic^verif/patches/mic.cocci
 plugin-spatch=list_*^verif/patches/list.cocci
 plugin-spatch=linked_n_*^verif/patches/list_ghost.cocci
+plugin-spatch=memb_init*^verif/patches/memb.cocci
 
 plugin=inline
 plugin-inline-text=begin^kernel_h^#include <string.h>
@@ -23,6 +24,7 @@ plugin-framac=galois_mul2^-wp -wp-overflows -wp-status-all
 plugin-framac=crc16_add^-wp -wp-overflows -wp-status-all
 plugin-framac=aes_128_set_padded_key^-wp -wp-rte -wp-status-all -wp-model 'Typed+Cast' -wp-prover alt-ergo -wp-prover cvc4-15
 plugin-framac=list_*^-wp -wp-rte -wp-status-all -wp-prop=-@lemma,-EASY_Left,-EASY_Right -wp-prover alt-ergo -wp-prover cvc4-15 -wp-timeout 10
+plugin-framac=memb_*^-wp -wp-rte -wp-status-all -wp-prop=-@lemma -wp-prover why3:alt-ergo -wp-timeout 20
 plugin-framac=-wp -wp-rte -wp-status-all -wp-prop=-@lemma -wp-prover alt-ergo -wp-prover cvc4-15 -wp-prover z3 -wp-timeout 20
 plugin-framac-verbose
 plugin-framac-verdicts

--- a/verif/fr
+++ b/verif/fr
@@ -60,6 +60,7 @@ frama-c						\
 	-wp-driver external.driver		\
 	-wp-script wp0.script			\
 	-wp-prover alt-ergo			\
+	-wp-prover why3:alt-ergo		\
 	-wp-prover cvc4				\
 	-wp-prover coq				\
 	"$@"

--- a/verif/patches/memb.cocci
+++ b/verif/patches/memb.cocci
@@ -1,0 +1,27 @@
+@memb_init@
+identifier m ;
+@@
+void
+memb_init(struct memb *m)
+{
+-  memset(m->used, 0, m->num);
++  /*@
++    loop invariant valid_memb(m) && i <= m->num ;
++    loop invariant \forall size_t j ; j < i ==> m->used[j] == false ;
++    loop assigns i, m->used[0 .. m->num - 1] ;
++    loop variant m->num - i ;
++  */
++  for(size_t i = 0 ; i < m->num ; ++i){
++    m->used[i] = false ;
++  }
++  // memset(m->used, 0, m->num);
+-  memset(m->mem, 0, m->size * m->num);
++  /*@
++    loop invariant valid_memb(m) && i <= m->num * m->size ;
++    loop invariant \forall size_t j ; j < i ==> ((char*)m->mem)[j] == 0 ;
++    loop assigns i, ((char*)m->mem)[0 .. m->size * m->num - 1] ;
++    loop variant m->num*m->size - i ;
++  */
++  for(size_t i = 0 ; i < m->num*m->size ; ++i) ((char*)m->mem)[i] = 0 ;
++  // memset(m->mem, 0, m->size * m->num);
+}


### PR DESCRIPTION
I let you check if the CI can still run correctly with the new proof settings. It adds a prover so it is not clear whether it will break something or not (in particular because of timeouts ...). 

The `memb_init` is still not entirely proved as it seems that there is some problems with the Typed memory model and the bool type.